### PR TITLE
fixes rightside padding on "add block" menus

### DIFF
--- a/assets/styles/editor-gutenberg.scss
+++ b/assets/styles/editor-gutenberg.scss
@@ -46,4 +46,8 @@
     min-height: 0 !important;
   }
 
+  input[type="search"]{
+    box-sizing: border-box;
+  }
+
 }


### PR DESCRIPTION
This css fixes the bad looking white space on the right side of block menu.

![Näyttökuva 2020-10-29 kello 7 53 17](https://user-images.githubusercontent.com/1336032/97532245-9210fe80-19be-11eb-9863-9b1080f639b5.png)
![Näyttökuva 2020-10-29 kello 7 53 11](https://user-images.githubusercontent.com/1336032/97532246-93422b80-19be-11eb-8771-8ea1313fe859.png)

However, the reason for this bug is old version of normalize.css.
Newest normalize.css fixed this bug - but it could change other things so I think it's best if you update it.

In that case, this PR is not needed.
